### PR TITLE
Modernizing Cmake files based on the output of gr_modtool

### DIFF
--- a/cmake/Modules/GrPython.cmake
+++ b/cmake/Modules/GrPython.cmake
@@ -36,11 +36,11 @@ if(PYTHON_EXECUTABLE)
 else(PYTHON_EXECUTABLE)
 
     #use the built-in find script
-    find_package(PythonInterp)
+    find_package(PythonInterp 2)
 
     #and if that fails use the find program routine
     if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python python2.7 python2.6 python2.5)
+        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7 python2.6 python2.5)
         if(PYTHON_EXECUTABLE)
             set(PYTHONINTERP_FOUND TRUE)
         endif(PYTHON_EXECUTABLE)

--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -33,7 +33,8 @@ include(GrPython)
 #   - GR_SWIG_DOCS_TARGET_DEPS
 ########################################################################
 function(GR_SWIG_MAKE_DOCS output_file)
-    if(ENABLE_DOXYGEN)
+    find_package(Doxygen)
+    if(DOXYGEN_FOUND)
 
         #setup the input files variable list, quote formated
         set(input_files)
@@ -75,18 +76,17 @@ function(GR_SWIG_MAKE_DOCS output_file)
         #call the swig_doc script on the xml files
         add_custom_command(
             OUTPUT ${output_file}
-            DEPENDS ${input_files} ${stamp-file} ${OUTPUT_DIRECTORY}/xml/index.xml
+            DEPENDS ${input_files} ${OUTPUT_DIRECTORY}/xml/index.xml
             COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_DASH_B}
                 ${CMAKE_SOURCE_DIR}/docs/doxygen/swig_doc.py
                 ${OUTPUT_DIRECTORY}/xml
                 ${output_file}
-            COMMENT "Generating python docstrings for ${name}"
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs/doxygen
         )
 
-    else(ENABLE_DOXYGEN)
+    else(DOXYGEN_FOUND)
         file(WRITE ${output_file} "\n") #no doxygen -> empty file
-    endif(ENABLE_DOXYGEN)
+    endif(DOXYGEN_FOUND)
 endfunction(GR_SWIG_MAKE_DOCS)
 
 ########################################################################
@@ -105,35 +105,20 @@ endfunction(GR_SWIG_MAKE_DOCS)
 macro(GR_SWIG_MAKE name)
     set(ifiles ${ARGN})
 
-    # Shimming this in here to take care of a SWIG bug with handling
-    # vector<size_t> and vector<unsigned int> (on 32-bit machines) and
-    # vector<long unsigned int> (on 64-bit machines). Use this to test
-    # the size of size_t, then set SIZE_T_32 if it's a 32-bit machine
-    # or not if it's 64-bit. The logic in gr_type.i handles the rest.
-    INCLUDE (CheckTypeSize)
-    CHECK_TYPE_SIZE("size_t" SIZEOF_SIZE_T)
-    CHECK_TYPE_SIZE("unsigned int" SIZEOF_UINT)
-    if(${SIZEOF_SIZE_T} EQUAL ${SIZEOF_UINT})
-      list(APPEND GR_SWIG_FLAGS -DSIZE_T_32)
-    endif(${SIZEOF_SIZE_T} EQUAL ${SIZEOF_UINT})
-
     #do swig doc generation if specified
     if (GR_SWIG_DOC_FILE)
         set(GR_SWIG_DOCS_SOURCE_DEPS ${GR_SWIG_SOURCE_DEPS})
-        list(APPEND GR_SWIG_DOCS_TARGET_DEPS ${GR_SWIG_TARGET_DEPS})
+        set(GR_SWIG_DOCS_TAREGT_DEPS ${GR_SWIG_TARGET_DEPS})
         GR_SWIG_MAKE_DOCS(${GR_SWIG_DOC_FILE} ${GR_SWIG_DOC_DIRS})
-        add_custom_target(${name}_swig_doc DEPENDS ${GR_SWIG_DOC_FILE})
-        list(APPEND GR_SWIG_TARGET_DEPS ${name}_swig_doc ${GR_RUNTIME_SWIG_DOC_FILE})
+        list(APPEND GR_SWIG_SOURCE_DEPS ${GR_SWIG_DOC_FILE})
     endif()
 
     #append additional include directories
-    find_package(PythonLibs)
+    find_package(PythonLibs 2)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_PATH}) #deprecated name (now dirs)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
-
-    #prepend local swig directories
-    list(INSERT GR_SWIG_INCLUDE_DIRS 0 ${CMAKE_CURRENT_SOURCE_DIR})
-    list(INSERT GR_SWIG_INCLUDE_DIRS 0 ${CMAKE_CURRENT_BINARY_DIR})
+    list(APPEND GR_SWIG_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+    list(APPEND GR_SWIG_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
 
     #determine include dependencies for swig file
     execute_process(
@@ -219,25 +204,21 @@ file(WRITE ${CMAKE_BINARY_DIR}/get_swig_deps.py "
 
 import os, sys, re
 
-i_include_matcher = re.compile('%(include|import)\\s*[<|\"](.*)[>|\"]')
-h_include_matcher = re.compile('#(include)\\s*[<|\"](.*)[>|\"]')
+include_matcher = re.compile('[#|%]include\\s*[<|\"](.*)[>|\"]')
 include_dirs = sys.argv[2].split(';')
 
 def get_swig_incs(file_path):
-    if file_path.endswith('.i'): matcher = i_include_matcher
-    else: matcher = h_include_matcher
     file_contents = open(file_path, 'r').read()
-    return matcher.findall(file_contents, re.MULTILINE)
+    return include_matcher.findall(file_contents, re.MULTILINE)
 
 def get_swig_deps(file_path, level):
     deps = [file_path]
     if level == 0: return deps
-    for keyword, inc_file in get_swig_incs(file_path):
+    for inc_file in get_swig_incs(file_path):
         for inc_dir in include_dirs:
             inc_path = os.path.join(inc_dir, inc_file)
             if not os.path.exists(inc_path): continue
             deps.extend(get_swig_deps(inc_path, level-1))
-            break #found, we dont search in lower prio inc dirs
     return deps
 
 if __name__ == '__main__':

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,10 +46,22 @@ list(APPEND display_sources
     show_text_window.cc
 )
 
+set(display_sources "${display_sources}" PARENT_SCOPE)
+if(NOT display_sources)
+	MESSAGE(STATUS "No C++ sources... skipping lib/")
+	return()
+endif(NOT display_sources)
+
 add_library(gnuradio-display SHARED ${display_sources})
 target_link_libraries(gnuradio-display ${Boost_LIBRARIES}
 	${GNURADIO_RUNTIME_LIBRARIES} ${QT_LIBRARIES} ${PYTHON_LIBRARIES})
 set_target_properties(gnuradio-display PROPERTIES DEFINE_SYMBOL "gnuradio_display_EXPORTS")
+
+if(APPLE)
+    set_target_properties(gnuradio-display PROPERTIES
+        INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
+    )
+endif(APPLE)
 
 ########################################################################
 # Install built library files


### PR DESCRIPTION
I modernized the CMake files using the following method
1. `gr_modtool newmod display` to create a new project
2. Copy over all `CMakeLists.txt` and `.cmake` files from the new project
3. Re-add sources to `CMakeLists.txt` files

This fixes the issue on OSX where `_display_swig.so` would have hardcoded links to all libraries except for `libgnuradio-display.dylib`.
