### PR TITLE
Fix compilation issue with boost

### DIFF
--- a/lib/display_text_msg_impl.cc
+++ b/lib/display_text_msg_impl.cc
@@ -30,7 +30,7 @@
 #include <gnuradio/prefs.h>
 
 #include <boost/lexical_cast.hpp>
-
+#include <boost/format.hpp>
 namespace gr {
 namespace display {
 


### PR DESCRIPTION
Compilation fails due to missing boost format.hpp import.